### PR TITLE
fix: verified repo master -> main rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 work
 node_modules
 .nodenv-vars
+.idea

--- a/main.ts
+++ b/main.ts
@@ -100,7 +100,7 @@ export class Main {
    * Get the verified plugins list
    */
   async getVerifiedPluginsList() {
-    const response = await axios.get<string[]>('https://raw.githubusercontent.com/homebridge/verified/master/verified-plugins.json');
+    const response = await axios.get<string[]>('https://raw.githubusercontent.com/homebridge/verified/main/verified-plugins.json');
     this.pluginList = response.data.filter(x => !this.pluginFilter.includes(x));
     console.log(`Processing ${this.pluginList.length} verified plugins...`);
 
@@ -145,7 +145,7 @@ export class Main {
 
   /**
    * Get the github release for the project
-   * @param version 
+   * @param version
    */
   async getGitHubRelease(tag: string) {
     const response = await this.octokit.request('GET /repos/{owner}/{repo}/releases', {
@@ -374,7 +374,7 @@ export class Main {
 
   /**
    * Delete a release asset
-   * @param asset 
+   * @param asset
    */
   async deleteAsset(asset) {
     try {


### PR DESCRIPTION
The [homebridge/verified](https://github.com/homebridge/verified) changed its default branch from `master` to `main`.

This updates the `main.ts` file to refer to the new branch.

Should fix failing actions https://github.com/homebridge/plugin-repo/actions